### PR TITLE
Fix for showroom issue causing build fails

### DIFF
--- a/test/showroom/test-element-with-props.js
+++ b/test/showroom/test-element-with-props.js
@@ -3,6 +3,8 @@ const assert = require('assert');
 describe('test-element-with-props', () => {
     it('should render from attributes', async function() {
         await showroom.setTestSubject('test-element-with-props');
+        // Workaround for showroom issue: https://github.com/eavichay/showroom/issues/11
+        await new Promise(resolve=>setTimeout(()=>resolve(), 10));
 
         const checkbox = await showroom.find('// input');
         const p = await showroom.find('// p');

--- a/test/showroom/test-element-with-state.js
+++ b/test/showroom/test-element-with-state.js
@@ -3,6 +3,8 @@ const assert = require('assert');
 describe('test-element-with-state', () => {
     it('should useState hook', async function() {
         await showroom.setTestSubject('test-element-with-state');
+        // Workaround for showroom issue: https://github.com/eavichay/showroom/issues/11
+        await new Promise(resolve=>setTimeout(()=>resolve(), 10));
 
         const span = await showroom.find('// span');
         const numClicks = parseInt(await showroom.getTextContent(span));

--- a/test/showroom/test-element.js
+++ b/test/showroom/test-element.js
@@ -3,6 +3,9 @@ const assert = require('assert');
 describe('test-component', () => {
     it('do basic render', async function() {
         await showroom.setTestSubject('test-element');
+        // Workaround for showroom issue: https://github.com/eavichay/showroom/issues/11
+        await new Promise(resolve=>setTimeout(()=>resolve(), 10));
+
         const p = await showroom.find('// p');
         const text = await showroom.getTextContent(p);
         assert.strictEqual(text, "Hello World");


### PR DESCRIPTION
Added short timeout when setting target element in showroom tests as a workaround for this showroom issue: https://github.com/eavichay/showroom/issues/11